### PR TITLE
Add pyproject.toml

### DIFF
--- a/dsctl.py
+++ b/dsctl.py
@@ -310,8 +310,7 @@ def flow(args: argparse.Namespace, config: Config) -> bool:
     else:
         return validate(config, schema, token, schema_type, args.includes_meta)
 
-
-if __name__ == "__main__":
+def main():
     arguments = parse_arguments()
     config = get_config()
 
@@ -327,4 +326,5 @@ if __name__ == "__main__":
         if not flow(arguments, config):
             sys.exit(1)
 
-    sys.exit(0)
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[project]
+name = "snowplow-dsctl"
+version = "0.0.1"
+description = "Data Structures Control, or dsctl, is a client to the Snowplow BDP Data Structures API."
+requires-python = ">=3.7"
+readme = {file = "README.md", content-type = "text/markdown"}
+keywords = ["snowplow", "iglu", "jsonschema"]
+authors = [
+  {name = "Snowplow Analytics"}
+]
+maintainers = [
+  {name = "Costas Kotsokalis", email = "costas@snowplowanalytics.com"}
+]
+urls = {Repository = "https://github.com/snowplow-incubator/dsctl"}
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Natural Language :: English",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Topic :: File Formats :: JSON :: JSON Schema",
+  "Topic :: Software Development :: Quality Assurance",
+  "Topic :: Utilities",
+]
+dependencies = [
+  "requests==2.27.1",
+  "python-dotenv==0.20.0",
+]
+
+[project.optional-dependencies]
+test = [
+  "pytest==7.1.1",
+  "pytest-mock==3.7.0",
+  "responses==0.20.0",
+]
+
+[project.scripts]
+dsctl = "dsctl:main"
+
+[tool.setuptools]
+py-modules = ["dsctl"]


### PR DESCRIPTION
Add project metadata via `pyproject.toml`.

This will make the repo installable via pip: `pip install git+https://github.com/snowplow-incubator/dsctl` which currently fails because the package doesn't include a `setup.py` or `pyproject.toml` file.

I also moved the module-level entry point into a `main()` function because the console entry point that setuptools creates requires a reference to a callable to create an executable in $PATH.